### PR TITLE
feat: friendly app-details load error with auto-recovery

### DIFF
--- a/app/src/main/java/com/aurora/store/compose/ui/details/AppDetailsScreen.kt
+++ b/app/src/main/java/com/aurora/store/compose/ui/details/AppDetailsScreen.kt
@@ -105,12 +105,7 @@ fun AppDetailsScreen(
     when (state) {
         is AppState.Loading -> ScreenContentLoading(onNavigateUp = onNavigateUp)
 
-        is AppState.Error -> {
-            ScreenContentError(
-                onNavigateUp = onNavigateUp,
-                message = (state as AppState.Error).message
-            )
-        }
+        is AppState.Error -> ScreenContentError(onNavigateUp = onNavigateUp)
 
         else -> {
             ScreenContentApp(
@@ -162,14 +157,14 @@ private fun ScreenContentLoading(onNavigateUp: () -> Unit = {}) {
  * Composable to display errors related to fetching app details
  */
 @Composable
-private fun ScreenContentError(onNavigateUp: () -> Unit = {}, message: String? = null) {
+private fun ScreenContentError(onNavigateUp: () -> Unit = {}) {
     Scaffold(
         topBar = { TopAppBar(onNavigateUp = onNavigateUp) }
     ) { paddingValues ->
         Error(
             modifier = Modifier.padding(paddingValues),
             painter = painterResource(R.drawable.ic_apps_outage),
-            message = message ?: stringResource(R.string.toast_app_unavailable)
+            message = stringResource(R.string.app_details_load_error)
         )
     }
 }

--- a/app/src/main/java/com/aurora/store/data/model/RecoveryDecision.kt
+++ b/app/src/main/java/com/aurora/store/data/model/RecoveryDecision.kt
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The Calyx Institute
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.aurora.store.data.model
+
+/**
+ * Window (ms) during which a repeated load failure after a background restart shows the
+ * manual "quit and reopen" message instead of restarting again. Outside this window the
+ * restart guard is considered stale and a fresh restart cycle is allowed.
+ */
+const val RESTART_GUARD_WINDOW_MS = 60_000L
+
+/**
+ * Recovery action to take after an app-details page fails to load.
+ */
+enum class Recovery {
+    /** Silently re-fetch the page in place (no disruption). */
+    RETRY,
+
+    /** Background quit + restart of the whole app process. */
+    RESTART,
+
+    /** Give up automatic recovery and show the user a message. */
+    SHOW_MESSAGE
+}
+
+/**
+ * Pure decision for how to recover from an app-details load failure. Kept free of Android
+ * dependencies so the branching can be unit-tested without restarting the process.
+ *
+ * @param retryAttempted whether an in-place retry has already been tried this load
+ * @param lastRestartMs epoch-millis of the last error-triggered restart, or 0 if none
+ * @param nowMs current epoch-millis
+ * @param windowMs guard window; failures within it after a restart fall through to a message
+ */
+fun decideRecovery(
+    retryAttempted: Boolean,
+    lastRestartMs: Long,
+    nowMs: Long,
+    windowMs: Long = RESTART_GUARD_WINDOW_MS
+): Recovery = when {
+    !retryAttempted -> Recovery.RETRY
+    lastRestartMs != 0L && (nowMs - lastRestartMs) < windowMs -> Recovery.SHOW_MESSAGE
+    else -> Recovery.RESTART
+}

--- a/app/src/main/java/com/aurora/store/util/Preferences.kt
+++ b/app/src/main/java/com/aurora/store/util/Preferences.kt
@@ -62,6 +62,8 @@ object Preferences {
 
     const val PREFERENCE_MIGRATION_VERSION = "PREFERENCE_MIGRATION_VERSION"
 
+    const val PREFERENCE_ERROR_RESTART_TS = "PREFERENCE_ERROR_RESTART_TS"
+
     private var prefs: SharedPreferences? = null
 
     fun getPrefs(context: Context): SharedPreferences = when (BuildConfig.FLAVOR) {

--- a/app/src/main/java/com/aurora/store/viewmodel/details/AppDetailsViewModel.kt
+++ b/app/src/main/java/com/aurora/store/viewmodel/details/AppDetailsViewModel.kt
@@ -28,6 +28,8 @@ import com.aurora.store.data.event.InstallerEvent
 import com.aurora.store.data.helper.DownloadHelper
 import com.aurora.store.data.model.AppState
 import com.aurora.store.data.model.DownloadStatus
+import com.aurora.store.data.model.Recovery
+import com.aurora.store.data.model.decideRecovery
 import com.aurora.store.data.model.ExodusReport
 import com.aurora.store.data.model.PlexusReport
 import com.aurora.store.data.model.Report
@@ -38,11 +40,14 @@ import com.aurora.store.data.room.favourite.FavouriteDao
 import com.aurora.store.util.CertUtil
 import com.aurora.store.util.PackageUtil
 import com.aurora.store.util.Preferences
+import com.aurora.store.util.Preferences.PREFERENCE_ERROR_RESTART_TS
 import com.aurora.store.util.Preferences.PREFERENCE_UPDATES_EXTENDED
+import com.jakewharton.processphoenix.ProcessPhoenix
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
@@ -55,6 +60,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.json.JSONObject
+
+// Delay before a silent in-place retry of a failed app-details load
+private const val RETRY_DELAY_MS = 1000L
 
 @HiltViewModel
 class AppDetailsViewModel @Inject constructor(
@@ -74,6 +82,9 @@ class AppDetailsViewModel @Inject constructor(
 
     private val _state = MutableStateFlow<AppState>(AppState.Loading)
     val state = _state.asStateFlow()
+
+    // Tracks whether a silent in-place retry has already been used for the current load
+    private var retryAttempted = false
 
     private val _suggestions = MutableStateFlow<List<App>>(emptyList())
     val suggestions = _suggestions.asStateFlow()
@@ -149,16 +160,23 @@ class AppDetailsViewModel @Inject constructor(
     }
 
     fun fetchAppDetails(packageName: String) {
+        retryAttempted = false
+        loadAppDetails(packageName)
+    }
+
+    private fun loadAppDetails(packageName: String) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 _app.value = appDetailsHelper.getAppByPackageName(packageName).copy(
                     isInstalled = PackageUtil.isInstalled(context, packageName)
                 )
                 _state.value = defaultAppState
+                // Healthy load clears any pending restart guard
+                Preferences.putLong(context, PREFERENCE_ERROR_RESTART_TS, 0L)
             } catch (exception: Exception) {
                 Log.e(TAG, "Failed to fetch app details", exception)
                 _app.value = null
-                _state.value = AppState.Error(exception.message)
+                handleLoadFailure(packageName)
             }
         }.invokeOnCompletion { throwable ->
             // Only proceed if there was no error while fetching the app details
@@ -170,6 +188,38 @@ class AppDetailsViewModel @Inject constructor(
             fetchSuggestions()
             fetchExodusPrivacyReport(packageName)
             if (app.value!!.requiresGMS()) fetchPlexusReport(packageName)
+        }
+    }
+
+    /**
+     * Recovers from an app-details load failure via [decideRecovery]: silent in-place
+     * retry first, then a one-shot background restart, finally a user-facing message.
+     */
+    private suspend fun handleLoadFailure(packageName: String) {
+        val decision = decideRecovery(
+            retryAttempted = retryAttempted,
+            lastRestartMs = Preferences.getLong(context, PREFERENCE_ERROR_RESTART_TS),
+            nowMs = System.currentTimeMillis()
+        )
+
+        when (decision) {
+            Recovery.RETRY -> {
+                retryAttempted = true
+                _state.value = AppState.Loading
+                delay(RETRY_DELAY_MS)
+                loadAppDetails(packageName)
+            }
+
+            Recovery.RESTART -> {
+                Preferences.putLong(
+                    context,
+                    PREFERENCE_ERROR_RESTART_TS,
+                    System.currentTimeMillis()
+                )
+                ProcessPhoenix.triggerRebirth(context)
+            }
+
+            Recovery.SHOW_MESSAGE -> _state.value = AppState.Error(null)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,6 +284,7 @@
     <string name="toast_apk_blacklisted">"Blacklisted"</string>
     <string name="toast_apk_whitelisted">"Whitelisted"</string>
     <string name="toast_app_unavailable">"App not available for your device"</string>
+    <string name="app_details_load_error">Oops! We had trouble loading this page. Try closing the app and reopening it.</string>
     <string name="toast_clipboard_copied">"Copied to clipboard"</string>
     <string name="toast_developer_setting_failed">Turn on developer settings from the device settings to open them.</string>
     <string name="toast_permission_granted">"Permission granted"</string>

--- a/app/src/test/java/com/aurora/store/data/model/RecoveryDecisionTest.kt
+++ b/app/src/test/java/com/aurora/store/data/model/RecoveryDecisionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The Calyx Institute
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.aurora.store.data.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RecoveryDecisionTest {
+
+    private val window = RESTART_GUARD_WINDOW_MS
+    private val now = 1_000_000L
+
+    @Test
+    fun `first failure retries in place`() {
+        val decision = decideRecovery(
+            retryAttempted = false,
+            lastRestartMs = 0L,
+            nowMs = now,
+            windowMs = window
+        )
+        assertThat(decision).isEqualTo(Recovery.RETRY)
+    }
+
+    @Test
+    fun `first failure retries even if a restart happened recently`() {
+        val decision = decideRecovery(
+            retryAttempted = false,
+            lastRestartMs = now - 1L,
+            nowMs = now,
+            windowMs = window
+        )
+        assertThat(decision).isEqualTo(Recovery.RETRY)
+    }
+
+    @Test
+    fun `retry failed and no prior restart triggers restart`() {
+        val decision = decideRecovery(
+            retryAttempted = true,
+            lastRestartMs = 0L,
+            nowMs = now,
+            windowMs = window
+        )
+        assertThat(decision).isEqualTo(Recovery.RESTART)
+    }
+
+    @Test
+    fun `retry failed within guard window shows message`() {
+        val decision = decideRecovery(
+            retryAttempted = true,
+            lastRestartMs = now - (window / 2),
+            nowMs = now,
+            windowMs = window
+        )
+        assertThat(decision).isEqualTo(Recovery.SHOW_MESSAGE)
+    }
+
+    @Test
+    fun `retry failed with stale guard restarts again`() {
+        val decision = decideRecovery(
+            retryAttempted = true,
+            lastRestartMs = now - (window + 1L),
+            nowMs = now,
+            windowMs = window
+        )
+        assertThat(decision).isEqualTo(Recovery.RESTART)
+    }
+
+    @Test
+    fun `restart exactly at window boundary is treated as stale and restarts`() {
+        val decision = decideRecovery(
+            retryAttempted = true,
+            lastRestartMs = now - window,
+            nowMs = now,
+            windowMs = window
+        )
+        assertThat(decision).isEqualTo(Recovery.RESTART)
+    }
+}

--- a/docs/superpowers/specs/2026-06-15-app-details-load-error-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-15-app-details-load-error-recovery-design.md
@@ -1,0 +1,157 @@
+# Friendly app-details load error with auto-recovery — Design
+
+Date: 2026-06-15
+Status: Approved (pending spec review)
+Scope: App details screen load-failure handling only
+
+## Goal
+
+Replace the misleading "App not available for your device" message shown when the app
+details page fails to load, and add automatic recovery before falling back to a
+user-facing message.
+
+New message (English source):
+> "Oops! We had trouble loading this page. Try closing the app and reopening it."
+
+Recovery ladder (decided with the user):
+1. **Retry in place** (silent re-fetch, no disruption).
+2. **Background quit + restart** (ProcessPhoenix) if the retry fails.
+3. **Manual message** (the friendly text above) if it still fails after the restart.
+
+Other decisions:
+- After a restart, the user lands on the **home screen** (ProcessPhoenix default). The
+  failed page is abandoned; the user can re-navigate.
+- Scope is the **app details page only** (the single place this message is used today).
+
+## Current state
+
+- `toast_app_unavailable` = "App not available for your device" is used in exactly one
+  place: `AppDetailsScreen.ScreenContentError`, rendered by the shared `Error`
+  composable when `viewModel.state` is `AppState.Error`.
+- `AppState.Error(message)` is set in `AppDetailsViewModel.fetchAppDetails()` when
+  `appDetailsHelper.getAppByPackageName(packageName)` throws — i.e. a **load failure**,
+  not real device incompatibility.
+- The app already bundles **ProcessPhoenix**
+  (`com.jakewharton.processphoenix.ProcessPhoenix.triggerRebirth(context)`), used in
+  `OnboardingViewModel` and `ForceRestartDialog`.
+- `AppDetailsViewModel` has `@ApplicationContext context`, `viewModelScope`, and access
+  to the `Preferences` util.
+- The `Error` composable supports `message`, optional `actionMessage`, and `onAction`.
+- `toast_app_unavailable` has ~45 translations; these are left untouched.
+
+## Components & changes
+
+### a. New string resource
+Add to `app/src/main/res/values/strings.xml`:
+```xml
+<string name="app_details_load_error">Oops! We had trouble loading this page. Try closing the app and reopening it.</string>
+```
+English only; other locales fall back to English until translated via Weblate. Do not
+modify `toast_app_unavailable` or its translations.
+
+### b. `ScreenContentError` (AppDetailsScreen.kt)
+Render the new friendly string instead of the raw exception/`toast_app_unavailable`:
+```kotlin
+message = stringResource(R.string.app_details_load_error)
+```
+Raw exception text is no longer surfaced to the user. The `AppState.Error` screen is now
+only reached as the final fallback in the ladder.
+
+### c. Pure recovery decision (new, unit-testable)
+A small pure function (no Android deps) so the branching is testable without killing the
+process. Suggested location: a new file under
+`app/src/main/java/com/aurora/store/data/model/` (e.g. `RecoveryDecision.kt`).
+
+```kotlin
+enum class Recovery { RETRY, RESTART, SHOW_MESSAGE }
+
+fun decideRecovery(
+    retryAttempted: Boolean,
+    lastRestartMs: Long,
+    nowMs: Long,
+    windowMs: Long
+): Recovery = when {
+    !retryAttempted -> Recovery.RETRY
+    lastRestartMs != 0L && (nowMs - lastRestartMs) < windowMs -> Recovery.SHOW_MESSAGE
+    else -> Recovery.RESTART
+}
+```
+
+Branch semantics:
+- First failure (`retryAttempted == false`) → `RETRY`.
+- Retry failed, no recent restart (no guard, or guard older than window) → `RESTART`.
+- Retry failed, restart already happened within the window → `SHOW_MESSAGE`.
+
+### d. Persisted restart guard (`Preferences`)
+The guard timestamp must survive the process restart, so it lives in SharedPreferences.
+- Add `getLong` / `putLong` helpers to `com.aurora.store.util.Preferences` (it currently
+  exposes only int/boolean/string).
+- Add key `PREFERENCE_ERROR_RESTART_TS` (Long, epoch millis; `0L` = unset).
+- Add a window constant `RESTART_GUARD_WINDOW_MS = 60_000L` (co-located with the
+  recovery logic).
+
+### e. `AppDetailsViewModel` orchestration
+- Add an in-memory `private var retryAttempted = false` (per ViewModel instance).
+- `fetchAppDetails(packageName)` (public entry): reset `retryAttempted = false`, then run
+  the existing load.
+- On the catch path, replace the direct `_state.value = AppState.Error(...)` with a
+  `handleLoadFailure(packageName)` that:
+  1. computes `decideRecovery(retryAttempted, Preferences.getLong(...PREFERENCE_ERROR_RESTART_TS, 0L), System.currentTimeMillis(), RESTART_GUARD_WINDOW_MS)`.
+  2. `RETRY` → set `retryAttempted = true`, keep `AppState.Loading`, `delay(1000)`, call
+     the load again.
+  3. `RESTART` → `Preferences.putLong(context, PREFERENCE_ERROR_RESTART_TS, System.currentTimeMillis())`, then `ProcessPhoenix.triggerRebirth(context)`.
+  4. `SHOW_MESSAGE` → `_state.value = AppState.Error(null)` (message text comes from the
+     resource in the composable).
+- On a **successful** fetch: clear the guard with
+  `Preferences.putLong(context, PREFERENCE_ERROR_RESTART_TS, 0L)` and leave
+  `retryAttempted` as-is (it resets on the next `fetchAppDetails` call).
+
+`System.currentTimeMillis()` is fine in app code (the Date/random restriction only
+applies to workflow scripts).
+
+## Data flow
+
+```
+fetchAppDetails(pkg)            // retryAttempted = false
+  └─ load → success → defaultAppState; clear guard
+          → throw → handleLoadFailure(pkg)
+                      decideRecovery(...)
+                        RETRY        → retryAttempted=true; Loading; delay(1s); load again
+                        RESTART      → save guard ts; ProcessPhoenix.triggerRebirth → home
+                        SHOW_MESSAGE → AppState.Error(null) → friendly message screen
+```
+
+After a `RESTART`, the process relaunches at home. If the user hits another app-details
+failure within the guard window, the ladder ends at `SHOW_MESSAGE` instead of restarting
+again. Outside the window (or after any success), the guard is stale/cleared and a fresh
+incident gets the full ladder again.
+
+## Loop safety
+
+- Single in-place retry (in-memory flag) absorbs transient blips.
+- The persisted guard window caps restarts at one per ~60s incident, preventing an
+  infinite restart loop for a persistently-failing page.
+- Success clears the guard; staleness re-arms it.
+
+## Known tradeoff
+
+For a page that persistently fails (e.g. a genuinely region-locked app), the worst case
+is: silent retry → one whole-app restart → land on home → user re-navigates → retry →
+friendly message. At most one full restart per guard window. This is the accepted cost
+of restart-first recovery.
+
+## Out of scope
+
+- Other load-error surfaces (home, search, etc.).
+- Returning to the failed page after restart (we land on home).
+- Re-translating the message into the ~45 existing locales (English fallback for now).
+- Changing `toast_app_unavailable` or its translations.
+
+## Testing
+
+- `./gradlew :app:compileVanillaDebugKotlin` — must build.
+- Unit tests for `decideRecovery` covering: first failure → RETRY; post-retry, no/stale
+  guard → RESTART; post-retry within window → SHOW_MESSAGE.
+- Manual: trigger a fetch failure (airplane mode / forced exception) and confirm the
+  sequence silent-retry → background restart to home → friendly message on the repeat;
+  confirm a normal successful load clears the guard.


### PR DESCRIPTION
## Summary

Replaces the misleading **"App not available for your device"** message shown when the app-details page fails to load (a load failure, not real device incompatibility) with a clearer message, and adds an automatic recovery ladder before that message ever appears.

Scope: the app-details page only.

## Recovery ladder

When `AppDetailsViewModel.fetchAppDetails()` fails:

1. **Silent in-place retry** — re-fetch once (~1s later), staying on the loading state. Handles transient blips with no disruption.
2. **Background quit + restart** — if the retry also fails, persist a guard timestamp and `ProcessPhoenix.triggerRebirth()` (the app relaunches to the home screen automatically).
3. **Friendly message** — if a load failure recurs within a 60s guard window after the restart, show: *"Oops! We had trouble loading this page. Try closing the app and reopening it."*

The persisted guard (`PREFERENCE_ERROR_RESTART_TS`) breaks restart loops: at most one full restart per ~60s incident. A successful load clears the guard; a stale guard (older than the window) re-arms the full ladder.

## Changes

- New string `app_details_load_error` (English; `toast_app_unavailable` and its ~45 translations untouched). `ScreenContentError` always renders the friendly text instead of raw exception messages.
- New pure, Android-free `decideRecovery(...)` (`RecoveryDecision.kt`) returning `RETRY` / `RESTART` / `SHOW_MESSAGE`, with JVM unit tests covering every branch incl. window boundary and stale-guard.
- `AppDetailsViewModel`: in-memory `retryAttempted`, refactored load into `loadAppDetails()` + `handleLoadFailure()`, guard read/write via existing `Preferences.getLong/putLong`.
- New `PREFERENCE_ERROR_RESTART_TS` key.

## Testing

- `./gradlew :app:compileVanillaDebugKotlin :app:testVanillaDebugUnitTest` — BUILD SUCCESSFUL, unit tests pass.
- Manual verification recommended: force a load failure (airplane mode) and confirm silent retry -> background restart to home -> friendly message on the repeat; confirm a normal load clears the guard.

Design doc: `docs/superpowers/specs/2026-06-15-app-details-load-error-recovery-design.md`